### PR TITLE
kb:#what added a callout and an internal link to the GET timesheets d…

### DIFF
--- a/source/includes/APIReference/Timesheets/_retrieve.md.erb
+++ b/source/includes/APIReference/Timesheets/_retrieve.md.erb
@@ -4,6 +4,10 @@
 
 Retrieves a list of all timesheets associated with your company, with filters to narrow down the results.
 
+<aside class="notice">
+Please see our <a href="#reports">reporting</a> endpoint Timesheet aggregations.
+</aside>
+
 ### HTTP Request
 
 <img src="images/get.png" alt="get"/><api>https://rest.tsheets.com/api/v1/timesheets</api>


### PR DESCRIPTION
…ocs indicating that we have a reporting endpoint #why to encourage API consumers to use our reporting endpoint for timesheet aggregations instead of having them pulling and aggregating time data via individual timesheet entries