### PR TITLE
Feat/code templates

### DIFF
--- a/source/includes/CodeTemplates/_delete.md.erb
+++ b/source/includes/CodeTemplates/_delete.md.erb
@@ -1,9 +1,12 @@
- > **Example**: <%= description %>
+ <% if defined? base_url -%>
+  <% @base_url = base_url -%>
+<% else -%>
+  <% @base_url = "https://rest.tsheets.com/api/v1/" -%>
+<% end -%>
 
- > Request
+<% @full_url = "#{@base_url}#{endpoint}" -%>
 
- <% @full_url = "https://rest.tsheets.com/api/v1/#{endpoint}" -%>
- <% if defined? parameters -%>
+<% if defined? parameters -%>
   <% @params = [] -%>
   <% parameters.each do |kvp| -%>
     <% @params.push(kvp.join('=')) -%>
@@ -11,22 +14,53 @@
   <% @full_url += "?#{@params.join('&')}" -%>  
 <% end -%>
 
+<% if defined? headers -%>
+  <% @headers = headers -%>
+<% else -%>
+  <% @headers = [ [ "Authorization", "Bearer <TOKEN>" ] ] -%>
+<% end -%>
+
+ > **Example**: <%= description %>
+
+ > Request
+
 ```shell
 <%= "curl -X DELETE \"#{@full_url}\"" %>
-  -H "Authorization: Bearer <TOKEN>"
+<% @headers.each do |header| -%>
+  <%= "-H \"#{header[0]}: #{header[1]}\" \\" %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+  <%= "-H \"#{header[0]}: #{header[1]}\" \\" %>
+  <% end -%>
+<% end -%>
 ```
 
 ```csharp
 <%= "var client = new RestClient(\"#{@full_url}\");" %>
 var request = new RestRequest(Method.DELETE);
-request.AddHeader("Authorization", "Bearer <TOKEN>");
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
+  <% end -%>
+<% end -%>
 IRestResponse response = client.Execute(request);
 ```
 
 ```vb
 <%= "Dim client = New RestClient(\"#{@full_url}\")" %>
 Dim request = New RestRequest(Method.[DELETE])
-request.AddHeader("Authorization", "Bearer <TOKEN>")
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
+<% end -%>
 Dim response As IRestResponse = client.Execute(request)
 ```
 
@@ -36,7 +70,14 @@ OkHttpClient client = new OkHttpClient();
 Request request = new Request.Builder()
   <%= ".url(\"#{@full_url}\")" %>
   .delete()
-  .addHeader("Authorization", "Bearer <TOKEN>")
+<% @headers.each do |header| -%>
+  <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+<% end -%>  
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+  <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
+<% end -%> 
   .build();
 
 Response response = client.newCall(request).execute();
@@ -49,8 +90,14 @@ var settings = {
   <%= "\"url\": \"#{@full_url}\"," %>
   "method": "DELETE",
   "headers": {
-    "Authorization": "Bearer <TOKEN>",
-    "cache-control": "no-cache"
+  <% @headers.each do |header| -%>
+    <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
+  <% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+    <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
+  <% end -%>
+<% end -%>
   }
 }
 
@@ -72,7 +119,16 @@ var options = { method: 'DELETE',
   },
 <% end %>
   headers: 
-   { Authorization: 'Bearer <TOKEN>' } };
+   {
+  <% @headers.each do |header| -%>
+     <%= "'#{header[0]}': '#{header[1]}'," %>
+  <% end -%>
+  <% if defined? extra_headers -%>
+    <% extra_headers.each do |header| -%>
+     <%= "'#{header[0]}': '#{header[1]}'," %>
+    <% end -%>
+  <% end -%>     
+   } };
 
 request(options, function (error, response, body) {
   if (error) throw new Error(error);
@@ -97,7 +153,14 @@ $request->setQueryData(array(
 <% end %>
 
 $request->setHeaders(array(
-  'Authorization' => 'Bearer <TOKEN>'
+  <% @headers.each do |header| -%>
+  <%= "'#{header[0]}' => '#{header[1]}'," %>
+  <% end -%>
+  <% if defined? extra_headers -%>
+    <% extra_headers.each do |header| -%>
+  <%= "'#{header[0]}' => '#{header[1]}'," %>
+    <% end -%>
+  <% end -%>
 ));
 
 try {
@@ -118,7 +181,14 @@ require 'net/http'
 http = Net::HTTP.new(url.host, url.port)
 
 request = Net::HTTP::Delete.new(url)
-request["Authorization"] = 'Bearer <TOKEN>'
+<% @headers.each do |header| -%>
+<%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+<%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
+  <% end -%>
+<% end -%> 
 
 response = http.request(request)
 puts response.read_body
@@ -139,8 +209,15 @@ querystring = {
 
 payload = ""
 headers = {
-    'Authorization': "Bearer <TOKEN>"
-    }
+  <% @headers.each do |header| -%>
+   <%= "'#{header[0]}': \"#{header[1]}\"," %>
+  <% end -%>
+<% if defined? extra_headers -%>    
+  <% extra_headers.each do |header| -%>
+   <%= "'#{header[0]}': \"#{header[1]}\"," %>
+  <% end -%>
+<% end -%>
+  }
 
 <% if defined? parameters -%>
 response = requests.request("GET", url, data=payload, headers=headers, params=querystring)
@@ -166,7 +243,14 @@ func main() {
 
   req, _ := http.NewRequest("DELETE", url, nil)
 
-  req.Header.Add("Authorization", "Bearer <TOKEN>")
+<% @headers.each do |header| -%>
+  <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+  <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
+<% end -%>
 
   res, _ := http.DefaultClient.Do(req)
 
@@ -182,8 +266,14 @@ func main() {
 import Foundation
 
 let headers = [
-  "Authorization": "Bearer <TOKEN>",
-  "cache-control": "no-cache"
+  <% @headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%>   
+<% if defined? extra_headers -%>    
+  <% extra_headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%>    
+<% end %>
 ]
 
 let request = NSMutableURLRequest(
@@ -212,8 +302,14 @@ use REST::Client;
  
 my $client = REST::Client->new();
 
-$client->addHeader('Authorization', 'Bearer <TOKEN>');
-$client->addHeader('Accept', 'application/json');
+<% @headers.each do |header| -%>
+<%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>
+<% end -%> 
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+<%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>
+  <% end -%>    
+<% end %>
 
 <%= "$url=\"#{@full_url}\";" %> 
 

--- a/source/includes/CodeTemplates/_get.md.erb
+++ b/source/includes/CodeTemplates/_get.md.erb
@@ -1,47 +1,66 @@
- > **Example**: <%= description %>
+<% if defined? base_url -%>
+  <% @base_url = base_url -%>
+<% else -%>
+  <% @base_url = "https://rest.tsheets.com/api/v1/" -%>
+<% end -%>
 
- > Request
+<% @full_url = "#{@base_url}#{endpoint}" -%>
 
- <% @full_url = "https://rest.tsheets.com/api/v1/#{endpoint}" -%>
- <% if defined? parameters -%>
+<% if defined? parameters -%>
   <% @params = [] -%>
   <% parameters.each do |kvp| -%>
     <% @params.push(kvp.join('=')) -%>
   <% end -%>
   <% @full_url += "?#{@params.join('&')}" -%>  
+ <% end -%>
+
+<% if defined? headers -%>
+  <% @headers = headers -%>
+<% else -%>
+  <% @headers = [ [ "Authorization", "Bearer <TOKEN>" ] ] -%>
 <% end -%>
+
+ > **Example**: <%= description %>
+
+ > Request
 
 ```shell
 <%= "curl \"#{@full_url}\" \\" %>
+<% @headers.each do |header| -%>
+  <%= "-H \"#{header[0]}: #{header[1]}\" \\" %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= "-H \"#{header[0]}: #{header[1]}\" \\" %>
   <% end -%>
 <% end -%>
-  -H "Authorization: Bearer <TOKEN>"
 ```
 
 ```csharp
 <%= "var client = new RestClient(\"#{@full_url}\");" %>
 var request = new RestRequest(Method.GET);
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
   <% end -%>
 <% end -%> 
-request.AddHeader("Authorization", "Bearer <TOKEN>");
 IRestResponse response = client.Execute(request);
 ```
 
 ```vb
 <%= "Dim client = New RestClient(\"#{@full_url}\")" %>
 Dim request = New RestRequest(Method.[GET])
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
   <% end -%>
 <% end -%> 
-request.AddHeader("Authorization", "Bearer <TOKEN>")
 Dim response As IRestResponse = client.Execute(request)
 ```
 
@@ -51,12 +70,14 @@ OkHttpClient client = new OkHttpClient();
 Request request = new Request.Builder()
   <%= ".url(\"#{@full_url}\")" %>
   .get()
+<% @headers.each do |header| -%>
+  <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+<% end -%>  
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
   <% end -%>
 <% end -%>   
-  .addHeader("Authorization", "Bearer <TOKEN>")
   .build();
 
 Response response = client.newCall(request).execute();
@@ -69,13 +90,14 @@ var settings = {
   <%= "\"url\": \"#{@full_url}\"," %>
   "method": "GET",
   "headers": {
-    "Authorization": "Bearer <TOKEN>",
+  <% @headers.each do |header| -%>
+    <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
+  <% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
     <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
   <% end -%>
 <% end -%>     
-    "cache-control": "no-cache"
   }
 }
 
@@ -97,15 +119,16 @@ var options = { method: 'GET',
   },
 <% end %>
   headers: 
-<% if defined? extra_headers -%>
-   { 'Authorization': 'Bearer <TOKEN>',
-  <% extra_headers.each do |header| -%>
+   {
+  <% @headers.each do |header| -%>
      <%= "'#{header[0]}': '#{header[1]}'," %>
   <% end -%>
+  <% if defined? extra_headers -%>
+    <% extra_headers.each do |header| -%>
+     <%= "'#{header[0]}': '#{header[1]}'," %>
+    <% end -%>
+  <% end -%>     
    } };
-<% else %>
-   { 'Authorization': 'Bearer <TOKEN>' } };
-<% end -%>     
 
 request(options, function (error, response, body) {
   if (error) throw new Error(error);
@@ -130,16 +153,15 @@ $request->setQueryData(array(
 <% end %>
 
 $request->setHeaders(array(
-<% if defined? extra_headers -%>
-  'Authorization' => 'Bearer <TOKEN>',
-  <% extra_headers.each do |header| -%>
+  <% @headers.each do |header| -%>
   <%= "'#{header[0]}' => '#{header[1]}'," %>
   <% end -%>
+  <% if defined? extra_headers -%>
+    <% extra_headers.each do |header| -%>
+  <%= "'#{header[0]}' => '#{header[1]}'," %>
+    <% end -%>
+  <% end -%>
 ));
-<% else %>
-  'Authorization' => 'Bearer <TOKEN>'
-));
-<% end -%>
 
 try {
   $response = $request->send();
@@ -159,7 +181,9 @@ require 'net/http'
 http = Net::HTTP.new(url.host, url.port)
 
 request = Net::HTTP::Get.new(url)
-request["Authorization"] = 'Bearer <TOKEN>'
+<% @headers.each do |header| -%>
+<%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
@@ -185,14 +209,14 @@ querystring = {
 
 payload = ""
 headers = {
-<% if defined? extra_headers -%>
-   'Authorization': "Bearer <TOKEN>",
+  <% @headers.each do |header| -%>
+   <%= "'#{header[0]}': \"#{header[1]}\"," %>
+  <% end -%>
+<% if defined? extra_headers -%>    
   <% extra_headers.each do |header| -%>
    <%= "'#{header[0]}': \"#{header[1]}\"," %>
   <% end -%>
-<% else %>
-   'Authorization': "Bearer <TOKEN>"
-<% end -%> 
+<% end -%>
   }
 
 <% if defined? parameters -%>
@@ -219,12 +243,14 @@ func main() {
 
   req, _ := http.NewRequest("GET", url, nil)
 
+<% @headers.each do |header| -%>
+  <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
   <% end -%>
 <% end -%> 
-  req.Header.Add("Authorization", "Bearer <TOKEN>")
 
   res, _ := http.DefaultClient.Do(req)
 
@@ -240,16 +266,14 @@ func main() {
 import Foundation
 
 let headers = [
-<% if defined? extra_headers -%>
-  "Authorization": "Bearer <TOKEN>",
+  <% @headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%>   
+<% if defined? extra_headers -%>    
   <% extra_headers.each do |header| -%>
    <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
   <% end -%>    
-  "cache-control": "no-cache"
-<% else %>
-  "Authorization": "Bearer <TOKEN>",
-  "cache-control": "no-cache"
-<% end -%> 
+<% end %>
 ]
 
 let request = NSMutableURLRequest(
@@ -281,8 +305,9 @@ use REST::Client;
  
 my $client = REST::Client->new();
 
-$client->addHeader('Authorization', 'Bearer <TOKEN>');
-$client->addHeader('Accept', 'application/json');
+<% @headers.each do |header| -%>
+<%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>
+<% end -%> 
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>

--- a/source/includes/CodeTemplates/_post-urlencoded.md.erb
+++ b/source/includes/CodeTemplates/_post-urlencoded.md.erb
@@ -1,3 +1,15 @@
+<% if defined? base_url -%>
+  <% @base_url = base_url -%>
+<% else -%>
+  <% @base_url = "https://rest.tsheets.com/api/v1/" -%>
+<% end -%>
+
+<% if defined? headers -%>
+  <% @headers = headers -%>
+<% else -%>
+  <% @headers = [ [ "Authorization", "Bearer <TOKEN>" ], [ "Content-Type", "application/x-www-form-urlencoded" ] ] -%>
+<% end -%>
+
 <% @urlencoded_body = urlencoded_params.map{|param| "#{param[0]}=#{param[1]}"}.join('&') -%>
 
  > **Example**: <%= description %>
@@ -15,41 +27,44 @@
 
 ```shell
 curl -X POST \
-  https://rest.tsheets.com/api/v1/<%= endpoint %> \
-  -H 'Authorization: Bearer <TOKEN>' \
+  <%= @base_url %><%= endpoint %> \
+  <% @headers.each do |header| -%>
+  <%= "-H '#{header[0]}: #{header[1]}' \\" %>
+  <% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= "-H '#{header[0]}: #{header[1]}' \\" %>
   <% end -%>
 <% end -%>
-  -H 'Content-Type: application/x-www-form-urlencoded' \
   -d '<%= @urlencoded_body %>'
 ```
 
 ```csharp
-var client = new RestClient("https://rest.tsheets.com/api/v1/<%= endpoint %>");
+var client = new RestClient("<%= @base_url %><%= endpoint %>");
 var request = new RestRequest(Method.POST);
-request.AddHeader("Authorization", "Bearer <TOKEN>");
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
   <% end -%>
-<% end -%>  
-request.AddHeader("Content-Type", "application/x-www-form-urlencoded");
+<% end -%>   
 request.AddParameter("application/x-www-form-urlencoded", "<%= @urlencoded_body %>", ParameterType.RequestBody);
 IRestResponse response = client.Execute(request);
 ```
 
 ```vb
-Dim client = New RestClient("https://rest.tsheets.com/api/v1/<%= endpoint %>")
+Dim client = New RestClient("<%= @base_url %><%= endpoint %>")
 Dim request = New RestRequest(Method.POST)
-request.AddHeader("Authorization", "Bearer <TOKEN>")
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
   <% end -%>
-<% end -%>   
-request.AddHeader("Content-Type", "application/x-www-form-urlencoded")
+<% end -%>
 request.AddParameter("application/x-www-form-urlencoded", "<%= @urlencoded_body %>", ParameterType.RequestBody);
 Dim response As IRestResponse = client.Execute(request)
 ```
@@ -60,15 +75,16 @@ OkHttpClient client = new OkHttpClient();
 MediaType mediaType = MediaType.parse("application/x-www-form-urlencoded");
 RequestBody body = RequestBody.create(mediaType, "<%= @urlencoded_body %>");
 Request request = new Request.Builder()
-  .url("https://rest.tsheets.com/api/v1/<%= endpoint %>")
+  .url("<%= @base_url %><%= endpoint %>")
   .post(body)
-  .addHeader("Authorization", "Bearer <TOKEN>")
+  <% @headers.each do |header| -%>
+  <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>  
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
   <% end -%>
-<% end -%>      
-  .addHeader("Content-Type", "application/x-www-form-urlencoded")
+<% end -%>
   .build();
 
 Response response = client.newCall(request).execute();
@@ -81,14 +97,14 @@ var settings = {
   <%= "\"url\": \"#{@full_url}\"," %>
   "method": "POST",
   "headers": {
-    "Authorization": "Bearer <TOKEN>",
-    "Content-Type": "application/x-www-form-urlencoded",
+  <% @headers.each do |header| -%>
+    <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
+  <% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
     <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
   <% end -%>
 <% end -%>        
-    "cache-control": "no-cache"
   },
   "processData": false,
   "data": {
@@ -111,15 +127,18 @@ $.ajax(settings).done(function (response) {
 var request = require("request");
 
 var options = { method: 'POST',
-  url: 'https://rest.tsheets.com/api/v1/<%= endpoint %>',
+  url: '<%= @base_url %><%= endpoint %>',
   headers: 
-   { 'Content-Type': 'application/x-www-form-urlencoded',
+  { 
+  <% @headers.each do |header| -%>
+     <%= "'#{header[0]}': '#{header[1]}'," %>
+  <% end -%>    
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
      <%= "'#{header[0]}': '#{header[1]}'," %>
   <% end -%>
 <% end -%>      
-     'Authorization': 'Bearer <TOKEN>' },
+  },
   form:
    {
   <% urlencoded_params.each_with_index do |param, index| -%>
@@ -142,17 +161,18 @@ request(options, function (error, response, body) {
 <?php
 
 $request = new HttpRequest();
-$request->setUrl('https://rest.tsheets.com/api/v1/<%= endpoint %>');
+$request->setUrl('<%= @base_url %><%= endpoint %>');
 $request->setMethod(HTTP_METH_POST);
 
 $request->setHeaders(array(
-  'Content-Type' => 'application/x-www-form-urlencoded',
+<% @headers.each do |header| -%>
+  <%= "'#{header[0]}' => '#{header[1]}'," %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= "'#{header[0]}' => '#{header[1]}'," %>
   <% end -%>
 <% end -%>   
-  'Authorization' => 'Bearer <TOKEN>'
 ));
 
 $request->setContentType('application/x-www-form-urlencoded');
@@ -179,18 +199,19 @@ try {
 require 'uri'
 require 'net/http'
 
-url = URI("https://rest.tsheets.com/api/v1/<%= endpoint %>")
+url = URI("<%= @base_url %><%= endpoint %>")
 
 http = Net::HTTP.new(url.host, url.port)
 
 request = Net::HTTP::Post.new(url)
-request["Authorization"] = 'Bearer <TOKEN>'
+<% @headers.each do |header| -%>
+<%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
   <% end -%>
-<% end -%>   
-request["Content-Type"] = 'application/x-www-form-urlencoded'
+<% end -%> 
 request.body = "<%= @urlencoded_body %>"
 
 response = http.request(request)
@@ -200,17 +221,18 @@ puts response.read_body
 ```python
 import requests
 
-url = "https://rest.tsheets.com/api/v1/<%= endpoint %>"
+url = "<%= @base_url %><%= endpoint %>"
 
 payload = "<%= @urlencoded_body %>"
 headers = {
-    'Authorization': "Bearer <TOKEN>",
+  <% @headers.each do |header| -%>
+    <%= "'#{header[0]}': '#{header[1]}'," %>
+  <% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
     <%= "'#{header[0]}': '#{header[1]}'," %>
   <% end -%>
 <% end -%>         
-    'Content-Type': "application/x-www-form-urlencoded"
     }
 
 response = requests.request("POST", url, data=payload, headers=headers)
@@ -230,19 +252,20 @@ import (
 
 func main() {
 
-  url := "https://rest.tsheets.com/api/v1/<%= endpoint %>"
+  url := "<%= @base_url %><%= endpoint %>"
 
   payload := strings.NewReader("<%= @urlencoded_body %>")
 
   req, _ := http.NewRequest("POST", url, payload)
 
-  req.Header.Add("Authorization", "Bearer <TOKEN>")
+  <% @headers.each do |header| -%>
+  <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
   <% end -%>
-<% end -%>      
-  req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+<% end -%> 
 
   res, _ := http.DefaultClient.Do(req)
 
@@ -260,16 +283,16 @@ import Foundation
 
 let headers = [
 <% if defined? extra_headers -%>
-  "Authorization": "Bearer <TOKEN>",
-  "Content-Type": "application/x-www-form-urlencoded",
+  <% @headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%> 
   <% extra_headers.each do |header| -%>
    <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
   <% end -%>    
-  "cache-control": "no-cache"
 <% else %>
-  "Authorization": "Bearer <TOKEN>",
-  "Content-Type": "application/x-www-form-urlencoded",
-  "cache-control": "no-cache"
+  <% @headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%> 
 <% end -%> 
 ]
 
@@ -312,10 +335,9 @@ use REST::Client;
  
 my $client = REST::Client->new();
 
-$client->addHeader('Authorization', 'Bearer <TOKEN>');
-$client->addHeader('Content-Type', 'application/x-www-form-urlencoded');
-$client->addHeader('charset', 'UTF-8');
-$client->addHeader('Accept', 'application/json');
+<% @headers.each do |header| -%>
+<%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>
+<% end -%>  
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>

--- a/source/includes/CodeTemplates/_post.md.erb
+++ b/source/includes/CodeTemplates/_post.md.erb
@@ -1,3 +1,15 @@
+<% if defined? base_url -%>
+  <% @base_url = base_url -%>
+<% else -%>
+  <% @base_url = "https://rest.tsheets.com/api/v1/" -%>
+<% end -%>
+
+<% if defined? headers -%>
+  <% @headers = headers -%>
+<% else -%>
+  <% @headers = [ [ "Authorization", "Bearer <TOKEN>" ], [ "Content-Type", "application/json" ] ] -%>
+<% end -%>
+
  > **Example**: <%= description %>
  
 <% if defined?(request_body) -%>
@@ -13,41 +25,44 @@
 
 ```shell
 curl -X POST \
-  https://rest.tsheets.com/api/v1/<%= endpoint %> \
-  -H 'Authorization: Bearer <TOKEN>' \
+  <%= @base_url %><%= endpoint %> \
+  <% @headers.each do |header| -%>
+  <%= "-H '#{header[0]}: #{header[1]}' \\" %>
+  <% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= "-H '#{header[0]}: #{header[1]}' \\" %>
   <% end -%>
 <% end -%>
-  -H 'Content-Type: application/json' \
   -d '<REQUEST BODY>'
 ```
 
 ```csharp
-var client = new RestClient("https://rest.tsheets.com/api/v1/<%= endpoint %>");
+var client = new RestClient("<%= @base_url %><%= endpoint %>");
 var request = new RestRequest(Method.POST);
-request.AddHeader("Authorization", "Bearer <TOKEN>");
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
   <% end -%>
 <% end -%>  
-request.AddHeader("Content-Type", "application/json");
 request.AddParameter("application/json", "<REQUEST BODY>", ParameterType.RequestBody);
 IRestResponse response = client.Execute(request);
 ```
 
 ```vb
-Dim client = New RestClient("https://rest.tsheets.com/api/v1/<%= endpoint %>")
+Dim client = New RestClient("<%= @base_url %><%= endpoint %>")
 Dim request = New RestRequest(Method.POST)
-request.AddHeader("Authorization", "Bearer <TOKEN>")
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
   <% end -%>
 <% end -%>   
-request.AddHeader("Content-Type", "application/json")
 request.AddParameter("application/json", "<REQUEST BODY>", ParameterType.RequestBody);
 Dim response As IRestResponse = client.Execute(request)
 ```
@@ -58,15 +73,16 @@ OkHttpClient client = new OkHttpClient();
 MediaType mediaType = MediaType.parse("application/json");
 RequestBody body = RequestBody.create(mediaType, "<REQUEST BODY>");
 Request request = new Request.Builder()
-  .url("https://rest.tsheets.com/api/v1/<%= endpoint %>")
+  .url("<%= @base_url %><%= endpoint %>")
   .post(body)
-  .addHeader("Authorization", "Bearer <TOKEN>")
+  <% @headers.each do |header| -%>
+  <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>  
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
   <% end -%>
 <% end -%>      
-  .addHeader("Content-Type", "application/json")
   .build();
 
 Response response = client.newCall(request).execute();
@@ -79,13 +95,14 @@ var settings = {
   <%= "\"url\": \"#{@full_url}\"," %>
   "method": "POST",
   "headers": {
-    "Authorization": "Bearer <TOKEN>",
+  <% @headers.each do |header| -%>
+    <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
+  <% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
     <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
   <% end -%>
 <% end -%>        
-    "cache-control": "no-cache"
   },
   "processData": false,
   "data": "<REQUEST BODY>"
@@ -100,15 +117,18 @@ $.ajax(settings).done(function (response) {
 var request = require("request");
 
 var options = { method: 'POST',
-  url: 'https://rest.tsheets.com/api/v1/<%= endpoint %>',
+  url: '<%= @base_url %><%= endpoint %>',
   headers: 
-   { 'Content-Type': 'application/json',
+  { 
+  <% @headers.each do |header| -%>
+     <%= "'#{header[0]}': '#{header[1]}'," %>
+  <% end -%>    
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
      <%= "'#{header[0]}': '#{header[1]}'," %>
   <% end -%>
 <% end -%>      
-     'Authorization': 'Bearer <TOKEN>' },
+  },
   body: '<REQUEST BODY>',
   json: true };
 
@@ -123,17 +143,18 @@ request(options, function (error, response, body) {
 <?php
 
 $request = new HttpRequest();
-$request->setUrl('https://rest.tsheets.com/api/v1/<%= endpoint %>');
+$request->setUrl('<%= @base_url %><%= endpoint %>');
 $request->setMethod(HTTP_METH_POST);
 
 $request->setHeaders(array(
-  'Content-Type' => 'application/json',
+<% @headers.each do |header| -%>
+  <%= "'#{header[0]}' => '#{header[1]}'," %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= "'#{header[0]}' => '#{header[1]}'," %>
   <% end -%>
 <% end -%>   
-  'Authorization' => 'Bearer <TOKEN>'
 ));
 
 $request->setBody('<REQUEST BODY>');
@@ -151,18 +172,19 @@ try {
 require 'uri'
 require 'net/http'
 
-url = URI("https://rest.tsheets.com/api/v1/<%= endpoint %>")
+url = URI("<%= @base_url %><%= endpoint %>")
 
 http = Net::HTTP.new(url.host, url.port)
 
 request = Net::HTTP::Post.new(url)
-request["Authorization"] = 'Bearer <TOKEN>'
+<% @headers.each do |header| -%>
+<%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
+<% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
   <% end -%>
 <% end -%>   
-request["Content-Type"] = 'application/json'
 request.body = "<REQUEST BODY>"
 
 response = http.request(request)
@@ -172,17 +194,18 @@ puts response.read_body
 ```python
 import requests
 
-url = "https://rest.tsheets.com/api/v1/<%= endpoint %>"
+url = "<%= @base_url %><%= endpoint %>"
 
 payload = "<REQUEST BODY>"
 headers = {
-    'Authorization': "Bearer <TOKEN>",
+  <% @headers.each do |header| -%>
+    <%= "'#{header[0]}': '#{header[1]}'," %>
+  <% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
     <%= "'#{header[0]}': '#{header[1]}'," %>
   <% end -%>
 <% end -%>         
-    'Content-Type': "application/json"
     }
 
 response = requests.request("POST", url, data=payload, headers=headers)
@@ -202,19 +225,20 @@ import (
 
 func main() {
 
-  url := "https://rest.tsheets.com/api/v1/<%= endpoint %>"
+  url := "<%= @base_url %><%= endpoint %>"
 
   payload := strings.NewReader("<REQUEST BODY>")
 
   req, _ := http.NewRequest("POST", url, payload)
 
-  req.Header.Add("Authorization", "Bearer <TOKEN>")
+  <% @headers.each do |header| -%>
+  <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
   <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
   <% end -%>
 <% end -%>      
-  req.Header.Add("Content-Type", "application/json")
 
   res, _ := http.DefaultClient.Do(req)
 
@@ -232,16 +256,16 @@ import Foundation
 
 let headers = [
 <% if defined? extra_headers -%>
-  "Authorization": "Bearer <TOKEN>",
-  "Content-Type": "application/json",
+  <% @headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%> 
   <% extra_headers.each do |header| -%>
    <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
   <% end -%>    
-  "cache-control": "no-cache"
 <% else %>
-  "Authorization": "Bearer <TOKEN>",
-  "Content-Type": "application/json",
-  "cache-control": "no-cache"
+  <% @headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%> 
 <% end -%> 
 ]
 let parameters = <REQUEST BODY> as [String : Any]
@@ -249,7 +273,7 @@ let parameters = <REQUEST BODY> as [String : Any]
 let postData = JSONSerialization.data(withJSONObject: parameters, options: [])
 
 let request = NSMutableURLRequest(
-  url: NSURL(string: "http://rest.tsheets.com/api/v1/<%= endpoint %>")! as URL,
+  url: NSURL(string: "<%= @base_url %><%= endpoint %>")! as URL,
   cachePolicy: .useProtocolCachePolicy,
   timeoutInterval: 10.0)
 
@@ -279,10 +303,9 @@ use REST::Client;
  
 my $client = REST::Client->new();
 
-$client->addHeader('Authorization', 'Bearer <TOKEN>');
-$client->addHeader('Content-Type', 'application/json');
-$client->addHeader('charset', 'UTF-8');
-$client->addHeader('Accept', 'application/json');
+<% @headers.each do |header| -%>
+<%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>
+<% end -%>  
 <% if defined? extra_headers -%>
   <% extra_headers.each do |header| -%>
 <%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>
@@ -291,7 +314,7 @@ $client->addHeader('Accept', 'application/json');
 
 $req = '<REQUEST BODY>';
 
-$url="http://rest.tsheets.com/api/v1/<%= endpoint %>"; 
+$url="<%= @base_url %><%= endpoint %>"; 
 
 $client->POST($url, $req);
 print $client->responseContent();

--- a/source/includes/CodeTemplates/_put.md.erb
+++ b/source/includes/CodeTemplates/_put.md.erb
@@ -1,3 +1,15 @@
+<% if defined? base_url -%>
+  <% @base_url = base_url -%>
+<% else -%>
+  <% @base_url = "https://rest.tsheets.com/api/v1/" -%>
+<% end -%>
+
+<% if defined? headers -%>
+  <% @headers = headers -%>
+<% else -%>
+  <% @headers = [ [ "Authorization", "Bearer <TOKEN>" ], [ "Content-Type", "application/json" ] ] -%>
+<% end -%>
+
  > **Example**: <%= description %>
  
 <% if defined?(request_body) -%>
@@ -7,31 +19,49 @@
 <%= request_body -%>
 
 ```
-<% end %>
+<% end -%>
 
  > Request
 
 ```shell
 curl -X PUT \
-  https://rest.tsheets.com/api/v1/<%= endpoint %> \
-  -H 'Authorization: Bearer <TOKEN>' \
-  -H 'Content-Type: application/json' \
+  <%= @base_url %><%= endpoint %> \
+  <% @headers.each do |header| -%>
+  <%= "-H '#{header[0]}: #{header[1]}' \\" %>
+  <% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+  <%= "-H '#{header[0]}: #{header[1]}' \\" %>
+  <% end -%>
+<% end -%>  
   -d '<REQUEST BODY>'
 ```
 
 ```csharp
-var client = new RestClient("https://rest.tsheets.com/api/v1/<%= endpoint %>");
+var client = new RestClient("<%= @base_url %><%= endpoint %>");
 var request = new RestRequest(Method.PUT);
-request.AddHeader("Content-Type", "application/json");
-request.AddHeader("Authorization", "Bearer <TOKEN>");
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\");" %>
+  <% end -%>
+<% end -%> 
 IRestResponse response = client.Execute(request);
 ```
 
 ```vb
-Dim client = New RestClient("https://rest.tsheets.com/api/v1/<%= endpoint %>")
+Dim client = New RestClient("<%= @base_url %><%= endpoint %>")
 Dim request = New RestRequest(Method.PUT)
-request.AddHeader("Authorization", "Bearer <TOKEN>")
-request.AddHeader("Content-Type", "application/json")
+<% @headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+<%= "request.AddHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
+<% end -%>
 Dim response As IRestResponse = client.Execute(request)
 ```
 
@@ -41,10 +71,16 @@ OkHttpClient client = new OkHttpClient();
 MediaType mediaType = MediaType.parse("application/json");
 RequestBody body = RequestBody.create(mediaType, "<REQUEST BODY>");
 Request request = new Request.Builder()
-  .url("https://rest.tsheets.com/api/v1/<%= endpoint %>")
+  .url("<%= @base_url %><%= endpoint %>")
   .put(body)
-  .addHeader("Authorization", "Bearer <TOKEN>")
-  .addHeader("Content-Type", "application/json")
+  <% @headers.each do |header| -%>
+  <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+  <%= ".addHeader(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
+<% end -%>   
   .build();
 
 Response response = client.newCall(request).execute();
@@ -57,8 +93,14 @@ var settings = {
   <%= "\"url\": \"#{@full_url}\"," %>
   "method": "PUT",
   "headers": {
-    "Authorization": "Bearer <TOKEN>",
-    "cache-control": "no-cache"
+  <% @headers.each do |header| -%>
+    <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
+  <% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+    <%= "\"#{header[0]}\", \"#{header[1]}\"," %>
+  <% end -%>
+<% end -%>  
   },
   "processData": false,
   "data": "<REQUEST BODY>"
@@ -73,10 +115,18 @@ $.ajax(settings).done(function (response) {
 var request = require("request");
 
 var options = { method: 'PUT',
-  url: 'https://rest.tsheets.com/api/v1/<%= endpoint %>',
+  url: '<%= @base_url %><%= endpoint %>',
   headers: 
-   { 'Content-Type': 'application/json',
-     Authorization: 'Bearer <TOKEN>' },
+  { 
+  <% @headers.each do |header| -%>
+     <%= "'#{header[0]}': '#{header[1]}'," %>
+  <% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+     <%= "'#{header[0]}': '#{header[1]}'," %>
+  <% end -%>
+<% end -%>  
+  },
   body: '<REQUEST BODY>',
   json: true };
 
@@ -91,12 +141,18 @@ request(options, function (error, response, body) {
 <?php
 
 $request = new HttpRequest();
-$request->setUrl('https://rest.tsheets.com/api/v1/<%= endpoint %>');
+$request->setUrl('<%= @base_url %><%= endpoint %>');
 $request->setMethod(HTTP_METH_PUT);
 
 $request->setHeaders(array(
-  'Content-Type' => 'application/json',
-  'Authorization' => 'Bearer <TOKEN>'
+<% @headers.each do |header| -%>
+  <%= "'#{header[0]}' => '#{header[1]}'," %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+  <%= "'#{header[0]}' => '#{header[1]}'," %>
+  <% end -%>
+<% end -%> 
 ));
 
 $request->setBody('<REQUEST BODY>');
@@ -114,13 +170,19 @@ try {
 require 'uri'
 require 'net/http'
 
-url = URI("https://rest.tsheets.com/api/v1/<%= endpoint %>")
+url = URI("<%= @base_url %><%= endpoint %>")
 
 http = Net::HTTP.new(url.host, url.port)
 
 request = Net::HTTP::Post.new(url)
-request["Authorization"] = 'Bearer <TOKEN>'
-request["Content-Type"] = 'application/json'
+<% @headers.each do |header| -%>
+<%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+<%= "request[\"#{header[0]}\"] = '#{header[1]}'," %>
+  <% end -%>
+<% end -%>
 request.body = "<REQUEST BODY>"
 
 response = http.request(request)
@@ -130,12 +192,18 @@ puts response.read_body
 ```python
 import requests
 
-url = "https://rest.tsheets.com/api/v1/<%= endpoint %>"
+url = "<%= @base_url %><%= endpoint %>"
 
 payload = "<REQUEST BODY>"
 headers = {
-    'Authorization': "Bearer <TOKEN>",
-    'Content-Type': "application/json"
+  <% @headers.each do |header| -%>
+    <%= "'#{header[0]}': '#{header[1]}'," %>
+  <% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+    <%= "'#{header[0]}': '#{header[1]}'," %>
+  <% end -%>
+<% end -%>  
     }
 
 response = requests.request("PUT", url, data=payload, headers=headers)
@@ -155,14 +223,20 @@ import (
 
 func main() {
 
-  url := "https://rest.tsheets.com/api/v1/<%= endpoint %>"
+  url := "<%= @base_url %><%= endpoint %>"
 
   payload := strings.NewReader("<REQUEST BODY>")
 
   req, _ := http.NewRequest("PUT", url, payload)
 
-  req.Header.Add("Authorization", "Bearer <TOKEN>")
-  req.Header.Add("Content-Type", "application/json")
+  <% @headers.each do |header| -%>
+  <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+  <%= "req.Header.Add(\"#{header[0]}\", \"#{header[1]}\")" %>
+  <% end -%>
+<% end -%>  
 
   res, _ := http.DefaultClient.Do(req)
 
@@ -179,9 +253,18 @@ func main() {
 import Foundation
 
 let headers = [
-  "Authorization": "Bearer <TOKEN>",
-  "Content-Type": "application/json",
-  "cache-control": "no-cache"
+<% if defined? extra_headers -%>
+  <% @headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%> 
+  <% extra_headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%>    
+<% else %>
+  <% @headers.each do |header| -%>
+   <%= "\"#{header[0]}\": \"#{header[1]}\"," %>
+  <% end -%> 
+<% end -%>  
 ]
 let parameters = <REQUEST BODY> as [String : Any]
 
@@ -218,10 +301,14 @@ use REST::Client;
  
 my $client = REST::Client->new();
 
-$client->addHeader('Authorization', 'Bearer <TOKEN>');
-$client->addHeader('Content-Type', 'application/json');
-$client->addHeader('charset', 'UTF-8');
-$client->addHeader('Accept', 'application/json');
+<% @headers.each do |header| -%>
+<%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>
+<% end -%>
+<% if defined? extra_headers -%>
+  <% extra_headers.each do |header| -%>
+<%= "$client->addHeader('#{header[0]}', '#{header[1]}');" %>
+  <% end -%>    
+<% end %>
 
 $req = '<REQUEST BODY>';
 

--- a/source/includes/Overview/_changelog.md.erb
+++ b/source/includes/Overview/_changelog.md.erb
@@ -16,3 +16,4 @@
 | 2019-07-16 | Fixing incorrect Invitations example |
 | 2019-08-12 | Updating support links |
 | 2019-09-04 | Adding the 'name' filter to the job codes GET operation |
+| 2019-09-23 | Updating code templates to allow overriding base URL and headers. |


### PR DESCRIPTION
Updating code templates to allow overriding base URL and headers.

Here's an example of how to use it:

<%= partial "includes/CodeTemplates/post.md.erb",
  :locals => {
  	:base_url => "https://tsheets.api.intuit.com/api/v1/",
    :endpoint => "clients",
    :description => "Create a new client.",
    :headers => [ [ "Authorization", "Intuit_APIKey  intuit_apikey=<APP_SECRET>, intuit_api_version=1.0" ],
                  [ "Cookie", "qbn.ptc.authid=12345678910; qbn.ptc.parentid=50000003; qbn.ptc.ticket=V1-65-Q3urwexsampledaru" ],
                  [ "Content-Type", "application/json" ],
                  [ "Accept", "application/json" ]
                ],
    :request_body => @request_body,
    :response_body => @response_body
  }
%>