### PR TITLE
Add new Effective Setting for two way sync

### DIFF
--- a/source/includes/APIReference/EffectiveSettings/Examples/_object.md.erb
+++ b/source/includes/APIReference/EffectiveSettings/Examples/_object.md.erb
@@ -143,7 +143,9 @@
   },
   "quickbooks": {
     "settings": {
-      "installed": 0
+      "installed": "1",
+      "connector": "qbia_online",
+      "two_way_sync_enabled_for_user": false
     },
     "last_modified": "2019-01-25T20:53:52+00:00"
   },

--- a/source/includes/APIReference/EffectiveSettings/Examples/_object.md.erb
+++ b/source/includes/APIReference/EffectiveSettings/Examples/_object.md.erb
@@ -145,7 +145,7 @@
     "settings": {
       "installed": "1",
       "connector": "qbia_online",
-      "two_way_sync_enabled_for_user": false
+      "two_way_sync_enabled_for_user": 0
     },
     "last_modified": "2019-01-25T20:53:52+00:00"
   },

--- a/source/includes/APIReference/EffectiveSettings/Examples/_retrieve-response.md.erb
+++ b/source/includes/APIReference/EffectiveSettings/Examples/_retrieve-response.md.erb
@@ -114,7 +114,7 @@
         "settings": {
           "installed": "1",
           "connector": "qbia_online",
-          "two_way_sync_enabled_for_user": false
+          "two_way_sync_enabled_for_user": 0
         },
         "last_modified": "2018-04-04T19:42:03+00:00"
       },

--- a/source/includes/APIReference/EffectiveSettings/Examples/_retrieve-response.md.erb
+++ b/source/includes/APIReference/EffectiveSettings/Examples/_retrieve-response.md.erb
@@ -112,7 +112,9 @@
       },
       "quickbooks": {
         "settings": {
-          "installed": 0
+          "installed": "1",
+          "connector": "qbia_online",
+          "two_way_sync_enabled_for_user": false
         },
         "last_modified": "2018-04-04T19:42:03+00:00"
       },

--- a/source/includes/Overview/_changelog.md.erb
+++ b/source/includes/Overview/_changelog.md.erb
@@ -17,3 +17,4 @@
 | 2019-08-12 | Updating support links |
 | 2019-09-04 | Adding the 'name' filter to the job codes GET operation |
 | 2019-09-23 | Updating code templates to allow overriding base URL and headers. |
+| 2019-10-03 | Updated code examples for Effective Settings to add two_way_sync_enabled_for_user setting |


### PR DESCRIPTION
lshort: #what Updated code examples for Effective Settings to add two_way_sync_enabled_for_user setting #why so that the mobile app and third party apps know if two way sync is enabled or not.