### PR TITLE
Add `show_to_all` property examples for customfields

### DIFF
--- a/source/includes/APIReference/CustomFieldItems/Examples/_retrieve-response.md.erb
+++ b/source/includes/APIReference/CustomFieldItems/Examples/_retrieve-response.md.erb
@@ -45,7 +45,8 @@
         "last_modified": "2018-04-04T16:04:00+00:00",
         "created": "2018-03-27T16:13:35+00:00",
         "ui_preference": "drop_down",
-        "required_customfields": [ ]
+        "required_customfields": [ ],
+        "show_to_all": true
       }
     }
   }

--- a/source/includes/APIReference/CustomFieldItems/Examples/_update-response.md.erb
+++ b/source/includes/APIReference/CustomFieldItems/Examples/_update-response.md.erb
@@ -32,7 +32,9 @@
         "regex_filter": "",
         "name": "Custom Field 1",
         "last_modified": "2018-07-23T23:09:14+00:00",
-        "created": "2018-07-23T23:09:14+00:00"
+        "created": "2018-07-23T23:09:14+00:00",
+        "required_customfields": [],
+        "show_to_all": false
       }
     }
   }

--- a/source/includes/APIReference/CustomFields/Examples/_create-response.md.erb
+++ b/source/includes/APIReference/CustomFields/Examples/_create-response.md.erb
@@ -16,7 +16,8 @@
         "last_modified": "2019-02-10T20:40:41+00:00",
         "created": "2019-02-10T20:40:41+00:00",
         "ui_preference": "dropdown",
-        "required_customfields": []
+        "required_customfields": [],
+        "show_to_all": true
       }
     }
   }

--- a/source/includes/APIReference/CustomFields/Examples/_object.md.erb
+++ b/source/includes/APIReference/CustomFields/Examples/_object.md.erb
@@ -10,5 +10,6 @@
   "last_modified": "2019-02-10T20:40:41+00:00",
   "created": "2019-02-03T18:36:16+00:00",
   "ui_preference": "drop_down",
-  "required_customfields": []
+  "required_customfields": [],
+  "show_to_all": false
 }

--- a/source/includes/APIReference/CustomFields/Examples/_retrieve-response.md.erb
+++ b/source/includes/APIReference/CustomFields/Examples/_retrieve-response.md.erb
@@ -13,9 +13,8 @@
         "last_modified": "2018-04-04T15:37:30+00:00",
         "created": "2018-03-27T16:13:35+00:00",
         "ui_preference": "drop_down",
-        "required_customfields": [
-
-        ]
+        "required_customfields": [ ],
+        "show_to_all": false
       },
       "195921": {
         "id": 195921,
@@ -29,9 +28,8 @@
         "last_modified": "2018-03-27T16:13:35+00:00",
         "created": "2018-03-27T16:13:35+00:00",
         "ui_preference": "text_box_with_suggest",
-        "required_customfields": [
-
-        ]
+        "required_customfields": [ ],
+        "show_to_all": true
       },
       "195919": {
         "id": 195919,
@@ -45,9 +43,8 @@
         "last_modified": "2018-03-27T16:13:35+00:00",
         "created": "2018-03-27T16:13:35+00:00",
         "ui_preference": "drop_down",
-        "required_customfields": [
-
-        ]
+        "required_customfields": [ ],
+        "show_to_all": true
       }
     }
   },

--- a/source/includes/APIReference/CustomFields/Examples/_update-response.md.erb
+++ b/source/includes/APIReference/CustomFields/Examples/_update-response.md.erb
@@ -16,7 +16,8 @@
         "last_modified": "2019-11-03T16:05:10+00:00",
         "created": "2019-02-10T20:40:41+00:00",
         "ui_preference": "dropdown",
-        "required_customfields": []
+        "required_customfields": [],
+        "show_to_all": true
       },
       "2": {
         "_status_code": 200,
@@ -33,7 +34,8 @@
         "last_modified": "2019-11-03T16:05:10+00:00",
         "created": "2019-02-10T20:40:41+00:00",
         "ui_preference": "dropdown",
-        "required_customfields": []
+        "required_customfields": [],
+        "show_to_all": true
       }
     }
   }


### PR DESCRIPTION
## Description
Add the `show_to_all` property to the examples for top-level customfields and customfields that appear in `customfielditems > supplemental_data`