### PR TITLE
Removing bearer token header from authorize endpoint examples.

### DIFF
--- a/source/includes/Overview/Examples/_authorize.tmpl.erb
+++ b/source/includes/Overview/Examples/_authorize.tmpl.erb
@@ -2,6 +2,7 @@
   :locals => {
     :endpoint => "authorize",
     :description => "Authorization Request.",
+    :headers => [],
     :parameters => [ [ "response_type", "code" ], [ "client_id", "MYAPPCLIENTID" ], [ "redirect_uri", "https://somedomain.com/callback" ], [ "state", "MYSTATE"] ]
   }
 %>

--- a/source/includes/Overview/Examples/_grant.tmpl.erb
+++ b/source/includes/Overview/Examples/_grant.tmpl.erb
@@ -4,6 +4,7 @@
   :locals => {
     :endpoint => "grant",
     :description => "Access Token Request.",
+    :headers => [],
     :urlencoded_params => [['grant_type', 'authorization_code'], ['client_id', 'MYAPPCLIENTID'], ['client_secret', 'MYAPPSECRET'],['code', 'bbcaef03191517dfb60d0305bfea38ea995af1az'], ['redirect_uri', 'https%3A%2F%2Fsomedomain.com%2Fcallback']],
     :response_body => @response_body
   }

--- a/source/includes/Overview/_authentication.md.erb
+++ b/source/includes/Overview/_authentication.md.erb
@@ -34,7 +34,7 @@ Once the user is directed to access the authorization endpoint at TSheets ('auth
 
  The link that a user will follow to perform an authorization request is made to the /authorize end-point:
 
- <%= partial "includes/Overview/Examples/authorize.tmpl.erb" %>
+<%= partial "includes/Overview/Examples/authorize.tmpl.erb" %>
 
 ### HTTP Request
 


### PR DESCRIPTION
## What
Removing bearer token header from `authorize` endpoint examples.

## Why
Inclusion of the header is unintentional, due to incorrect parameterization of the curl template.  It's not even possible to include it since there's not a token obtained yet by this point.