### PR TITLE
Change Pronouns and Display Names To Return Empty Strings in Examples

### DIFF
--- a/source/includes/APIReference/Users/Examples/_create-response.md.erb
+++ b/source/includes/APIReference/Users/Examples/_create-response.md.erb
@@ -24,8 +24,8 @@
         "client_url": "api_sample_output",
         "company_name": "API Sample Output Company",
         "profile_image_url": "",
-        "display_name": null,
-        "pronouns": null,
+        "display_name": "",
+        "pronouns": "",
         "mobile_number": "",
         "pto_balances": {
           "2624351": 0,
@@ -84,8 +84,8 @@
         "client_url": "api_sample_output",
         "company_name": "API Sample Output Company",
         "profile_image_url": "",
-        "display_name": null,
-        "pronouns": null,
+        "display_name": "",
+        "pronouns": "",
         "mobile_number": "",
         "pto_balances": {
           "2624351": 0,

--- a/source/includes/APIReference/Users/Examples/_object.md.erb
+++ b/source/includes/APIReference/Users/Examples/_object.md.erb
@@ -20,8 +20,8 @@
   "client_url": "api_sample_output",
   "company_name": "API Sample Output Company",
   "profile_image_url": "https:\/\/www.gravatar.com\/avatar\/e64c7d89f26bd1972efa854d13d7dd61",
-  "display_name": null,
-  "pronouns": null,
+  "display_name": "",
+  "pronouns": "",
   "pto_balances": {
     "2624351": 0,
     "2624353": 0,

--- a/source/includes/APIReference/Users/Examples/_retrieve-response.md.erb
+++ b/source/includes/APIReference/Users/Examples/_retrieve-response.md.erb
@@ -23,8 +23,8 @@
         "client_url": "api_sample_output",
         "company_name": "API Sample Output Company",
         "profile_image_url": "https:\/\/www.gravatar.com\/avatar\/e64c7d89f26bd1972efa854d13d7dd61",
-        "display_name": null,
-        "pronouns": null,
+        "display_name": "",
+        "pronouns": "",
         "pto_balances": {
           "2624351": 0,
           "2624353": 0,
@@ -80,8 +80,8 @@
         "client_url": "api_sample_output",
         "company_name": "API Sample Output Company",
         "profile_image_url": "",
-        "display_name": null,
-        "pronouns": null,
+        "display_name": "",
+        "pronouns": "",
         "mobile_number": "",
         "pto_balances": {
           "2624351": 0,

--- a/source/includes/APIReference/Users/Examples/_update-response.md.erb
+++ b/source/includes/APIReference/Users/Examples/_update-response.md.erb
@@ -24,8 +24,8 @@
         "client_url": "api_sample_output",
         "company_name": "API Sample Output Company",
         "profile_image_url": "https:\/\/www.gravatar.com\/avatar\/e64c7d89f26bd1972efa854d13d7dd61",
-        "display_name": null,
-        "pronouns": null,
+        "display_name": "",
+        "pronouns": "",
         "mobile_number": "2087231456",
         "pto_balances": {
           "2624351": 0,
@@ -86,8 +86,8 @@
         "client_url": "api_sample_output",
         "company_name": "API Sample Output Company",
         "profile_image_url": "",
-        "display_name": null,
-        "pronouns": null,
+        "display_name": "",
+        "pronouns": "",
         "mobile_number": "",
         "pto_balances": {
           "2624351": 0,


### PR DESCRIPTION
We shipped documentation changes without fixing the examples, this PR is to update the examples to reflect the new behavior for the display name and pronoun field on the user object.