### PR TITLE
Upgrading activesupport gem dependency, fix security alert CVE-2020-8…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ ruby '>=2.3.1'
 source 'https://rubygems.org'
 
 # Middleman
-gem 'activesupport', '5.0.7.2'
+gem 'activesupport', '5.2.4.3'
 gem 'addressable', '2.6.0'
 gem 'autoprefixer-rails', '6.7.7.2'
 gem 'backports', '3.15.0'


### PR DESCRIPTION
…165.  there is potentially unexpected behaviour in the MemCacheStore and RedisCacheStore where, when untrusted user input is written to the cache store using the raw: true parameter, re-reading the result from the cache can evaluate the user input as a Marshalled object instead of plain text.