### PR TITLE
http status code updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ ruby '>=2.3.1'
 source 'https://rubygems.org'
 
 # Middleman
-gem 'activesupport', '5.2.4.3'
+gem 'activesupport', '5.0.7.2'
 gem 'addressable', '2.6.0'
 gem 'autoprefixer-rails', '6.7.7.2'
 gem 'backports', '3.15.0'

--- a/source/includes/Overview/_changelog.md.erb
+++ b/source/includes/Overview/_changelog.md.erb
@@ -17,6 +17,7 @@
 | 2019-08-12 | Updating support links |
 | 2019-09-04 | Adding the 'name' filter to the job codes GET operation |
 | 2019-09-23 | Updating code templates to allow overriding base URL and headers. |
+| 2020-06-17 | Updating request formats to make response code documentation more accurate. |
 | 2019-10-03 | Updated code examples for Effective Settings to add two_way_sync_enabled_for_user setting |
 | 2019-11-19 | Adding the 'name' filter to the custom field items GET operation |
 | 2019-12-17 | Adding sections for 'Create Custom Fields' and 'Update Custom Fields' |

--- a/source/includes/Overview/_changelog.md.erb
+++ b/source/includes/Overview/_changelog.md.erb
@@ -17,7 +17,6 @@
 | 2019-08-12 | Updating support links |
 | 2019-09-04 | Adding the 'name' filter to the job codes GET operation |
 | 2019-09-23 | Updating code templates to allow overriding base URL and headers. |
-| 2020-06-17 | Updating request formats to make response code documentation more accurate. |
 | 2019-10-03 | Updated code examples for Effective Settings to add two_way_sync_enabled_for_user setting |
 | 2019-11-19 | Adding the 'name' filter to the custom field items GET operation |
 | 2019-12-17 | Adding sections for 'Create Custom Fields' and 'Update Custom Fields' |
@@ -28,3 +27,4 @@
 | 2020-03-18 | Updated notes for user fields 'display_name' and 'pronouns' as they are no longer null in any case |
 | 2020-03-24 | Updated notes for request throttling from 10 minute to 5 minute throttling window |
 | 2020-05-13 | Published Time Off Requests documentation |
+| 2020-06-17 | Updating request formats to make response code documentation more accurate. |

--- a/source/includes/Overview/_request_formats.md.erb
+++ b/source/includes/Overview/_request_formats.md.erb
@@ -26,16 +26,10 @@ You can delete an existing object by sending an `HTTP DELETE` action to the reso
 
 _Note: Some endpoints which do not support DELETE instead allow items to be "archived" (aka soft deleted). For example, you can make a PUT call with `active=false` to the [Users](#update-users) endpoint to remove a user._
 
-## Possible Response Status Codes
+## Possible HTTP Response Status Codes
 
 ### 2xx response codes
-All 2xx response codes indicate success for the action requested. Following are the most common 2xx response codes:
-
-|          |               |
-| -------: | :------------ |
-| <code class="level200s">200 OK</code> | The request was successful and the response body contains the response for the action requested. Usually comes in response to a GET request. |
-| <code class="level200s">201 Created</code> | The request was successful and the response body contains the response for the action requested. A _201_ indicates that changes may have been made on the server side to the object when the request was handled (e.g. a timesheet was split due to break settings). The caller should check the `supplemental_data` of the response to process any related changes. Usually comes in response to a POST (create) or PUT (update) request. |
-| <code class="level200s">202 Accepted</code> | The request was successful and the response body contains the response for the action requested. A _202_ indicates that the details of the create request match an already existing, active object. Rather than create a duplicate object, a _202_ is returned along with the id of the original object. Usually comes in response to a POST (create) request. |
+All 2xx response codes indicate that the request was successful. The response body contains any details for the action requested.
 
 ### 3xx response codes
 All 3xx response codes indicate that you need to look elsewhere for your result. The response body will contain directions on where you should be redirected to.
@@ -49,8 +43,7 @@ All 4xx response codes indicate failure for the action requested. Following are 
 | <code class="level400s">401 Unauthorized</code> | You don't have sufficient permission to perform the action you requested. |
 | <code class="level400s">402 Billing not current</code> | Your account billing is not current, so access was denied. |
 | <code class="level400s">405 Method Not Allowed</code> | The action you are trying to perform is not allowed. |
-| <code class="level400s">406 Not Acceptable</code> | The data you have tried to create conflicts with existing data. |
-| <code class="level400s">409 Conflict</code> | The data you have tried to modify conflicts with existing data. |
+| <code class="level400s">409 Conflict</code> | There is a conflict with the operation you're trying to perform (details in the response body). |
 | <code class="level400s">413 Max Items Exceeded</code> | The number of objects you are listing or editing or adding is too large. |
 | <code class="level400s">417 Expectation Failed</code> | Your request was missing required parameters or your request was somehow otherwise malformed. |
 | <code class="level400s">429 Too Many Requests</code> | You have sent too many requests to the API in too short a time. You'll have to try your requests again later. |
@@ -64,13 +57,16 @@ All 5xx response codes indicate a server error or exceptional condition on the T
 | <code class="level500s">501 Method not implemented</code> | This method is not implemented for this object. It may be in the future. |
 | <code class="level500s">503 (Various messages)</code> | A _503_ response code indicates that the service is temporarily unavailable. Wait a few minutes for the condition to clear, and try again. |
 
+### `_status_code`'s in the Response Body
+Please note that the API will include a `_status_code` in the response body associated with each element that was passed in a `POST` or `PUT` request.  These `_status_code`'s will have similar values to the HTTP Response codes listed above, but they don't necessarily have the same meaning.  You can find documentation on each `_status_code` that may be returned as part of each API endpoint's documentation.
+
 ## Response Formats
 
 <%= partial "includes/Overview/Examples/response_format.tmpl.erb" %>
 
-TSheets returns resource representations as JSON, unless an exception occurs. Each JSON response object will contain the response data underneath an object property labeled 'results'. 
+TSheets returns resource representations as JSON, unless an exception occurs. Each JSON response object will contain the response data underneath an object property labeled 'results'.
 
-For GET requests, in the response body there will also be a boolean with the name, "more". If true, it means that there is another page of objects that can be retrieved. Otherwise _false_ will be the value. 
+For GET requests, in the response body there will also be a boolean with the name, "more". If true, it means that there is another page of objects that can be retrieved. Otherwise _false_ will be the value.
 
 If the resource object references any other objects via an id (i.e. `group_id`), a corresponding JSON representation of that object will be contained in another top level property labeled `supplemental_data`.
 


### PR DESCRIPTION
Update documentation to make section around HTTP Status Codes more accurate.
It's easy to confuse HTTP status codes with our response body _status_code's.  This should help clarify.

Rolling back to previous version of activesupport gem
With the latest version, our macbuild.sh script was not working.  Getting various errors about "Bundler could not find compatible versions for gem ..." for several gems.  Will need to investigate what other gems need to be upgraded along with activesupport.
Security risk is minimal to nill, as our only use of Ruby is during our build process, so feel it's okay to rollback while we investigate.