### PR TITLE
Fixes #75

### DIFF
--- a/source/includes/APIReference/Timesheets/_retrieve.md.erb
+++ b/source/includes/APIReference/Timesheets/_retrieve.md.erb
@@ -31,3 +31,7 @@ Please see our <a href="#reports">reporting</a> endpoint Timesheet aggregations.
 | **per_page**<br/>optional | _Int_ | Represents how many results you'd like to retrieve per request (page). Default is 50. Max is 50. |
 | **page**<br/>optional | _Int_ | Represents the page of results you'd like to retrieve. Default is 1. |
 
+
+<aside class="notice">
+The maximum batch size is <i>50</i> timesheets. To receive the full result, increment the page parameter and iterate through the requests until you receive "more":false as part of the response.
+</aside>

--- a/source/includes/Overview/_welcome.md.erb
+++ b/source/includes/Overview/_welcome.md.erb
@@ -75,6 +75,10 @@ Found an error, or would otherwise like to contribute to our API documentation? 
 
 To prevent abuse of the TSheets API, we limit requests to a maximum of 300 calls within any 5 minute time window (subject to change). Rate limiting is primarily considered on a per-connection basis (per access token). If you exceed the current rate limit, you will receive a `429 'Too many requests'` response from our API. You will continue to receive a `429` response until you're out of the current time window. The threshold and time window may adjust dynamically downward if you are found to be abusing the system.
 
+## Response Size Limit
+
+Each request response will return a maximum of 50 results per page (regardless of whether the per_page parameter is sent with your request). To receive the full response, look for the `"more": true` attribute and iterate sending a new request with the page parameter incremented until you receive `"more": false` in the response payload.
+
 ## SDK's & Helper Libraries
 
 <a href="https://github.com/tsheets/api_dotnet"><img src="images/ms.net-logo.png" alt="ms.net-logo" style="float:left; width:15%; margin-right: 1%"/></a><a href="https://github.com/tsheets/api_phplib"><img src="images/php-logo.png" alt="php" style="float:left; width:10%; margin-right: 1%"/></a>


### PR DESCRIPTION
Adding more clarity to the response size limit in the beginning of the documentation as well as adding a statement in the retrieve timesheets section