### PR TITLE
Remove employee number from list of private fields

### DIFF
--- a/source/includes/APIReference/Users/_users.md.erb
+++ b/source/includes/APIReference/Users/_users.md.erb
@@ -69,7 +69,7 @@ The rights assignable to an individual user. All properties are _read-write_, an
 
 <aside class="notice">
 The following fields are considered <i>private</i> and are exposed only to managers and admins:
-  <code>employee_number</code>, <code>salaried</code>, <code>exempt</code>, <code>username</code>, <code>payroll_id</code>, <code>hire_date</code>,
+  <code>salaried</code>, <code>exempt</code>, <code>username</code>, <code>payroll_id</code>, <code>hire_date</code>,
   <code>term_date</code>, <code>mobile_number</code>, <code>submitted_to</code>, <code>approved_to</code>, <code>permissions</code> & <code>customfields</code>
 </aside>
 

--- a/source/includes/Overview/_changelog.md.erb
+++ b/source/includes/Overview/_changelog.md.erb
@@ -28,3 +28,4 @@
 | 2020-03-24 | Updated notes for request throttling from 10 minute to 5 minute throttling window |
 | 2020-05-13 | Published Time Off Requests documentation |
 | 2020-06-17 | Updating request formats to make response code documentation more accurate. |
+| 2020-10-19 | Remove employee_number from list of private fields |


### PR DESCRIPTION
Remove the employee_number from the list of fields considered private on the user endpoint. It was incorrectly included in the list of private fields but has been public for several years.

Note: We did a review and verified that the code was correct and docs were wrong.