### PR TITLE
Add documentation for the time_tracking permission

### DIFF
--- a/source/includes/APIReference/Timesheets/_create.md.erb
+++ b/source/includes/APIReference/Timesheets/_create.md.erb
@@ -49,6 +49,7 @@ Each timesheet that is created will come back with a `_status_code` and `_status
 | :-----: | :------- |
 | <code class="level200">200</code> | OK. Timesheet was created successfully. |
 | <code class="level200">201</code> | Fulfilled. Timesheet was created successfully. Other timesheets may have been modified as a result (i.e. due to timesheet splits or an automatic Lunch Break). Be sure to process entries for `timesheets` or `timesheets_deleted` in the `supplemental_data` portion of the response. |
+| <code class="level400">403</code> | Forbidden. TS-1006: User is not allowed to track time. |
 | <code class="level400">406</code> | Not Acceptable. Conflict exists with another timesheet. See the `_status_extra` value for more detail. |
 | <code class="level400">417</code> | Expectation Failed. Something was wrong or missing with the properties supplied for this timesheet. See the `_status_extra` value for more detail. |
 

--- a/source/includes/APIReference/Users/Examples/_create-response.md.erb
+++ b/source/includes/APIReference/Users/Examples/_create-response.md.erb
@@ -57,7 +57,8 @@
           "view_company_schedules": false,
           "view_group_schedules": false,
           "manage_no_schedules": false,
-          "view_my_schedules": false
+          "view_my_schedules": false,
+          "time_tracking": false
         },
         "customfields": ""
       },
@@ -117,7 +118,8 @@
           "view_company_schedules": false,
           "view_group_schedules": false,
           "manage_no_schedules": false,
-          "view_my_schedules": false
+          "view_my_schedules": false,
+          "time_tracking": false
         },
         "customfields": ""
       }

--- a/source/includes/APIReference/Users/Examples/_object.md.erb
+++ b/source/includes/APIReference/Users/Examples/_object.md.erb
@@ -54,7 +54,8 @@
     "view_company_schedules": false,
     "view_group_schedules": false,
     "manage_no_schedules": false,
-    "view_my_schedules": false
+    "view_my_schedules": false,
+    "time_tracking": false
   },
   "customfields": ""
 }

--- a/source/includes/APIReference/Users/Examples/_retrieve-response.md.erb
+++ b/source/includes/APIReference/Users/Examples/_retrieve-response.md.erb
@@ -55,7 +55,8 @@
           "view_company_schedules": false,
           "view_group_schedules": false,
           "manage_no_schedules": false,
-          "view_my_schedules": false
+          "view_my_schedules": false,
+          "time_tracking": false
         },
         "customfields": ""
       },
@@ -113,7 +114,8 @@
           "view_company_schedules": false,
           "view_group_schedules": false,
           "manage_no_schedules": false,
-          "view_my_schedules": false
+          "view_my_schedules": false,
+          "time_tracking": false
         },
         "customfields": ""
       }

--- a/source/includes/APIReference/Users/Examples/_update-response.md.erb
+++ b/source/includes/APIReference/Users/Examples/_update-response.md.erb
@@ -59,7 +59,8 @@
           "view_company_schedules": false,
           "view_group_schedules": false,
           "manage_no_schedules": false,
-          "view_my_schedules": false
+          "view_my_schedules": false,
+          "time_tracking": false
         },
         "customfields": ""
       },
@@ -121,7 +122,8 @@
           "view_company_schedules": false,
           "view_group_schedules": false,
           "manage_no_schedules": false,
-          "view_my_schedules": false
+          "view_my_schedules": false,
+          "time_tracking": false
         },
         "customfields": ""
       }

--- a/source/includes/APIReference/Users/_create.md.erb
+++ b/source/includes/APIReference/Users/_create.md.erb
@@ -21,6 +21,7 @@ For a full list of properties that may be set on a user, see [the User object](#
 
 <aside class="notice">
 By default, users will be created with the time_tracking permission set to false. Requests to create a timesheet for users in this state will result in a <code class="standout">403: Forbidden. TS-1006: User is not allowed to track time</code> HTTP response.
+To enable a user for time tracking, ensure you are setting the time_tracking permission to true for the user at create time.
 </aside>
 
 ### Status Codes

--- a/source/includes/APIReference/Users/_create.md.erb
+++ b/source/includes/APIReference/Users/_create.md.erb
@@ -19,6 +19,10 @@ _Pass an array of user objects as the value to a 'data' property (see example)._
 
 For a full list of properties that may be set on a user, see [the User object](#the-user-object).
 
+<aside class="notice">
+By default, users will be created with the time_tracking permission set to false. Requests to create a timesheet for users in this state will result in a <code class="standout">403: Forbidden. TS-1006: User is not allowed to track time</code> HTTP response.
+</aside>
+
 ### Status Codes
 Each user that is created will come back with a `_status_code` and `_status_message` that will indicate whether the user was created successfully. If there was a problem creating a user, there may also be an additional field, `_status_extra`, which will contain more details about the failure.
 

--- a/source/includes/APIReference/Users/_users.md.erb
+++ b/source/includes/APIReference/Users/_users.md.erb
@@ -66,6 +66,7 @@ The rights assignable to an individual user. All properties are _read-write_, an
 | **view_company_schedules** | false | Able to view published events within the schedule for any user in the company. |
 | **view_group_schedules** | false | Able to view published events within the schedule for the groups that the user is a member of. |
 | **view_my_schedules** | false | Able to view published events within the schedule for themselves. |
+| **time_tracking** | false | Able to track time and have time tracked on their behalf. |
 
 <aside class="notice">
 The following fields are considered <i>private</i> and are exposed only to managers and admins:

--- a/source/includes/Overview/_changelog.md.erb
+++ b/source/includes/Overview/_changelog.md.erb
@@ -29,3 +29,4 @@
 | 2020-05-13 | Published Time Off Requests documentation |
 | 2020-06-17 | Updating request formats to make response code documentation more accurate. |
 | 2020-10-19 | Remove employee_number from list of private fields |
+| 2020-11-24 | Adding documentation for time_tracking permission |


### PR DESCRIPTION
Add documentation for the user permission - time_tracking. Added this permission to the user response examples, added a note to the 'Create User' section to indicate that this permission is set to false by default, and how this will affect the ability to create timesheets for a user, and added the response to the 'Create Timesheets' section. 