### PR TITLE
adds the "active_jobcodes" param to assignments

### DIFF
--- a/source/includes/APIReference/JobcodeAssignments/_retrieve.md.erb
+++ b/source/includes/APIReference/JobcodeAssignments/_retrieve.md.erb
@@ -16,9 +16,9 @@ Retrieves a list of all jobcode assignments associated with users, with optional
 | **jobcode_id**<br/>optional | _Int_ | If specified, only assignments for jobcodes with the given id are returned. |
 | **jobcode_parent_id**<br/>optional | _Int_ | When omitted, all jobcode assignments are returned regardless of jobcode parent. If specified, only assignments for jobcodes with the given jobcode `parent_id` are returned. To get a list of only top-level jobcode assignments, pass in a `jobcode_parent_id` of _0_. |
 | **active**<br/>optional | _String_ | 'yes', 'no, or 'both'. Default is 'both'. 'yes' means the assignment is active, 'no' means it is deleted/inactive. |
+| **active_jobcodes**<br/>optional | _String_ | 'yes', 'no, or 'both'. Default is 'both'. 'yes' means only assignments where the jobcode is active, 'no' means only assignments where jobcodes are inactive. |
 | **modified_before**<br/>optional | _String_ | Only jobcode assignments modified before this date/time will be returned, in ISO 8601 format (`YYYY-MM-DDThh:mm:ss±hh:mm`). |
 | **modified_since**<br/>optional | _String_ | Only jobcode assignments modified since this date/time will be returned, in ISO 8601 format (`YYYY-MM-DDThh:mm:ss±hh:mm`). |
 | **supplemental_data**<br/>optional | _String_ | 'yes' or 'no'. Default is 'yes'. Indicates whether supplemental data should be returned. |
 | **per_page**<br/>optional | _Int_ | Represents how many results you'd like to retrieve per request (page). Default is 50. Max is 50. |
 | **page**<br/>optional | _Int_ | Represents the page of results you'd like to retrieve. Default is 1. |
-


### PR DESCRIPTION
Our serverside endpoint now allows the `active_jobcodes` param.  This gets assignments only for those jobcodes which are active.  