### PR TITLE
Update outdated properties and notice on invitations POST operation

### DIFF
--- a/source/includes/APIReference/Invitations/_create.md.erb
+++ b/source/includes/APIReference/Invitations/_create.md.erb
@@ -18,7 +18,7 @@ _Pass an array of invitation objects as the value to a 'data' property (see exam
 | **user_id**<br/>optional | _Int_ | Id of [User](#the-user-object) object.
 
 <aside class="notice">
-If <code>user_id</code> is not provided, <code>contact_info</code> is required and will be used to search for an existing user or create a new user. If both <code>user_id</code> and <code>contact_info</code> are present, the provided <code>contact_info</code> will be used to invite the user with the provided <code>user_id</code>.
+If <code>user_id</code> is not provided, <code>contact_info</code> is required and will be used to search for an existing user or create a new user. If both <code>user_id</code> and <code>contact_info</code> are present, the provided <code>contact_info</code> will be used to invite the user that has the provided <code>user_id</code>.
 </aside>
 
 ### Status Codes

--- a/source/includes/APIReference/Invitations/_create.md.erb
+++ b/source/includes/APIReference/Invitations/_create.md.erb
@@ -17,10 +17,6 @@ _Pass an array of invitation objects as the value to a 'data' property (see exam
 | **contact_info**<br/>required | _String_ | Email address or mobile phone number matching the type specified by the `contact_method` parameter.
 | **user_id**<br/>required | _Int_ | Id of [User](#the-user-object) object.
 
-<aside class="notice">
-The <code>contact_info</code> and <code>user_id</code> parameters are mutually exclusive.  One and only one must be supplied.
-</aside>
-
 ### Status Codes
 
 Each invitation that is created will come back with a `_status_code` and `_status_message` that will indicate whether the invitation was created successfully.  If there was a problem creating an invitation, there may also be an additional field, `_status_extra`, which will contain more details about the failure.

--- a/source/includes/APIReference/Invitations/_create.md.erb
+++ b/source/includes/APIReference/Invitations/_create.md.erb
@@ -14,8 +14,12 @@ _Pass an array of invitation objects as the value to a 'data' property (see exam
 |                |             |             |
 | -------------: | :---------: | ----------- |
 | **contact_method**<br/>required | _String_ | Method to be used for the invitation, either 'sms' or 'email' |
-| **contact_info**<br/>required | _String_ | Email address or mobile phone number matching the type specified by the `contact_method` parameter.
-| **user_id**<br/>required | _Int_ | Id of [User](#the-user-object) object.
+| **contact_info**<br/>optional | _String_ | Email address or mobile phone number matching the type specified by the `contact_method` parameter.
+| **user_id**<br/>optional | _Int_ | Id of [User](#the-user-object) object.
+
+<aside class="notice">
+If <code>user_id</code> is not provided, <code>contact_info</code> is required and will be used to search for an existing user or create a new user. If both <code>user_id</code> and <code>contact_info</code> are present, the provided <code>contact_info</code> will be used to invite the user with the provided <code>user_id</code>.
+</aside>
 
 ### Status Codes
 

--- a/source/includes/Overview/_changelog.md.erb
+++ b/source/includes/Overview/_changelog.md.erb
@@ -32,4 +32,4 @@
 | 2020-11-24 | Adding documentation for time_tracking permission |
 | 2021-01-15 | Adding documentation for Jobcode connect_with_quickbooks property |
 | 2021-05-17 | Adding new rebranded images, update text and addressed sidebar for same look and feel as QuickBooks |
-| 2021-08-04 | Remove outdated notice from invitaions POST operation |
+| 2021-08-04 | Update outdated property requirements and notice from invitaions POST operation |

--- a/source/includes/Overview/_changelog.md.erb
+++ b/source/includes/Overview/_changelog.md.erb
@@ -32,4 +32,4 @@
 | 2020-11-24 | Adding documentation for time_tracking permission |
 | 2021-01-15 | Adding documentation for Jobcode connect_with_quickbooks property |
 | 2021-05-17 | Adding new rebranded images, update text and addressed sidebar for same look and feel as QuickBooks |
-| 2021-08-04 | Update outdated property requirements and notice from invitaions POST operation |
+| 2021-08-04 | Update outdated property requirements and notice from invitations POST operation |

--- a/source/includes/Overview/_changelog.md.erb
+++ b/source/includes/Overview/_changelog.md.erb
@@ -32,3 +32,4 @@
 | 2020-11-24 | Adding documentation for time_tracking permission |
 | 2021-01-15 | Adding documentation for Jobcode connect_with_quickbooks property |
 | 2021-05-17 | Adding new rebranded images, update text and addressed sidebar for same look and feel as QuickBooks |
+| 2021-08-04 | Remove outdated notice from invitaions POST operation |


### PR DESCRIPTION
Pull request #8696 in Intuit's internal `tsheets-app` repository slightly changes the behavior of the invitations POST operation, and these docs aren't entirely accurate even prior to that change.

Neither the `contact_info` nor `user_id` properties are always required in the current implementation or with PR #8696. Despite the notice claiming these properties are mutually exclusive, consumers can and some do provide both of those properties in their requests. Prior to PR #8696, this endpoint would very rarely throw an exception for QBO-connected clients when both properties are provided stating that the caller can't provide both of them. For all other clients, the endpoint would respond with `200 OK` despite behaving unexpectedly. PR #8696 prevents this endpoint from throwing that edge case exception and makes it behave correctly when both of these properties are provided.